### PR TITLE
Improve hand animation with smoothed amplitude

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,9 +55,11 @@ def main(stdscr: curses.window) -> None:
     user_radius = DEFAULT_RADIUS
     user_ttl = DEFAULT_TTL
     message_timer = 0.0
+    smoothed_amplitude = 0.0
 
     while True:
         amplitude = get_amplitude_band()
+        smoothed_amplitude = (smoothed_amplitude * 0.9) + (amplitude * 0.1)
 
         key = stdscr.getch()
         if key == ord('+') or key == ord('='):
@@ -89,7 +91,7 @@ def main(stdscr: curses.window) -> None:
 
         draw_frame(
             stdscr,
-            amplitude,
+            smoothed_amplitude,
             show_banner,
             active_waves,
             user_radius,

--- a/visualizer.py
+++ b/visualizer.py
@@ -42,6 +42,11 @@ def draw_frame(
 
     center_y = height // 2
     center_x = width // 2
+    level_bar = f"Amplitude: {amplitude:.2f}"
+    try:
+        stdscr.addstr(0, 2, level_bar, curses.A_DIM)
+    except curses.error:
+        pass
     # 1. Draw expanding waves triggered by beats
     for wave in active_waves:
         ring_top = center_y - len(WAVE_TEMPLATE) // 2 - wave.radius
@@ -56,7 +61,7 @@ def draw_frame(
                 pass
 
     # 2. Draw hand based on amplitude level
-    if amplitude > 0.6:
+    if amplitude > 0.7:
         hand = HAND_FRAMES[1]
     elif amplitude > 0.3:
         hand = HAND_FRAMES[0]


### PR DESCRIPTION
## Summary
- smooth amplitude in `main` and use it for drawing the hand
- display a live amplitude value in the UI
- adjust the hand frame thresholds for clearer reactions

## Testing
- `python -m py_compile main.py visualizer.py audio_input.py frames.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688673ffa8d88322a35d302bf807e8d8