### PR TITLE
Add flame particle beat effects

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,9 +2,11 @@
 
 import curses
 import time
+import math
+import random
 
 from audio_input import get_amplitude_band
-from visualizer import draw_frame
+from visualizer import draw_frame, FlameParticle
 
 # Target frame rate of the curses UI
 FPS = 30
@@ -39,9 +41,8 @@ def main(stdscr: curses.window) -> None:
     stdscr.nodelay(True)
     stdscr.clear()
 
-    last_beat_time = 0.0
-    show_banner = False
     active_waves: list[Wave] = []
+    active_flames: list[FlameParticle] = []
     user_radius = DEFAULT_RADIUS
     user_ttl = DEFAULT_TTL
     message_timer = 0.0
@@ -64,22 +65,24 @@ def main(stdscr: curses.window) -> None:
             message_timer = time.time()
 
         if amplitude > BEAT_THRESHOLD:
-            show_banner = True
-            last_beat_time = time.time()
             active_waves.append(Wave(radius=user_radius, ttl=user_ttl))
-
-        if time.time() - last_beat_time > 0.3:
-            show_banner = False
+            for _ in range(8):
+                angle = random.uniform(0, 2 * math.pi)
+                radius = random.uniform(4, 6)
+                active_flames.append(FlameParticle(angle, radius, ttl=4))
 
         for wave in active_waves:
             wave.update()
         active_waves = [w for w in active_waves if w.is_alive()]
+        for flame in active_flames:
+            flame.update()
+        active_flames = [f for f in active_flames if f.ttl > 0]
 
         draw_frame(
             stdscr,
             amplitude,
-            show_banner,
             active_waves,
+            active_flames,
             user_radius,
             user_ttl,
             show_radius=(time.time() - message_timer < 2),

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,23 +1,55 @@
 import curses
 import math
+from typing import List
+
 from frames import OMARCHY_BANNER
+from utils import center_text
 
 
-def draw_frame(stdscr, amplitude, show_banner, waves, user_radius, user_ttl, show_radius=False):
+class FlameParticle:
+    """Represents a temporary flame emoji flying out from the center."""
+
+    def __init__(self, angle: float, radius: float = 1.0, ttl: int = 4) -> None:
+        self.angle = angle
+        self.radius = radius
+        self.ttl = ttl
+
+    def update(self) -> None:
+        """Advance the particle one step outward and reduce its life."""
+        self.radius += 1
+        self.ttl -= 1
+
+
+def draw_frame(
+    stdscr,
+    amplitude: float,
+    waves: List["Wave"],
+    flames: List[FlameParticle],
+    user_radius: int,
+    user_ttl: int,
+    show_radius: bool = False,
+) -> None:
     """Draw a single visualization frame."""
     stdscr.clear()
     height, width = stdscr.getmaxyx()
     center_y, center_x = height // 2, width // 2
 
-    # Draw OMARCHY banner
-    if show_banner:
-        for i, line in enumerate(OMARCHY_BANNER):
-            y = center_y - len(OMARCHY_BANNER) + i - 2
-            x = (width - len(line)) // 2
-            try:
-                stdscr.addstr(y, x, line, curses.A_BOLD)
-            except curses.error:
-                continue
+    # Draw OMARCHY banner centered at all times
+    for i, line in enumerate(OMARCHY_BANNER):
+        offset = i - len(OMARCHY_BANNER) // 2
+        try:
+            center_text(stdscr, line, y_offset=offset, attr=curses.A_BOLD)
+        except curses.error:
+            continue
+
+    # Draw flame particles
+    for flame in flames:
+        y = center_y + int(round(math.sin(flame.angle) * flame.radius))
+        x = center_x + int(round(math.cos(flame.angle) * flame.radius))
+        try:
+            stdscr.addstr(y, x, "\U0001F525")  # flame emoji
+        except curses.error:
+            continue
 
     # Draw waves
     for wave in waves:


### PR DESCRIPTION
## Summary
- center OMARCHY banner at all times
- show flame particles on each beat instead of flashing text
- manage flame particles and waves in main loop

## Testing
- `python -m py_compile *.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68867f2138f88322a0d77bf4aa789096