### PR TITLE
Fix OMARCHY banner position

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -29,3 +29,26 @@ def init_colors() -> int:
     curses.use_default_colors()
     curses.init_pair(1, curses.COLOR_RED, -1)
     return curses.color_pair(1)
+
+
+def draw_top_centered_text(stdscr: curses.window, text: str, y: int = 1, attr: int = curses.A_BOLD) -> None:
+    """Draw ``text`` centered horizontally near the top of ``stdscr``.
+
+    Parameters
+    ----------
+    stdscr : curses.window
+        The window to draw on.
+    text : str
+        Text to display.
+    y : int, optional
+        The row from the top where text should be drawn.
+    attr : int, optional
+        Additional attributes such as ``curses.A_BOLD``.
+    """
+    height, width = stdscr.getmaxyx()
+    x = max((width - len(text)) // 2, 0)
+    if 0 <= y < height:
+        try:
+            stdscr.addstr(y, x, text, attr)
+        except curses.error:
+            pass

--- a/visualizer.py
+++ b/visualizer.py
@@ -3,7 +3,7 @@ import math
 from typing import List
 
 from frames import OMARCHY_BANNER
-from utils import center_text
+from utils import draw_top_centered_text
 
 
 class FlameParticle:
@@ -34,13 +34,9 @@ def draw_frame(
     height, width = stdscr.getmaxyx()
     center_y, center_x = height // 2, width // 2
 
-    # Draw OMARCHY banner centered at all times
+    # Draw OMARCHY banner fixed at the top center
     for i, line in enumerate(OMARCHY_BANNER):
-        offset = i - len(OMARCHY_BANNER) // 2
-        try:
-            center_text(stdscr, line, y_offset=offset, attr=curses.A_BOLD)
-        except curses.error:
-            continue
+        draw_top_centered_text(stdscr, line, y=1 + i, attr=curses.A_BOLD)
 
     # Draw flame particles
     for flame in flames:


### PR DESCRIPTION
## Summary
- add `draw_top_centered_text` helper
- move OMARCHY banner to the top center so it always shows

## Testing
- `python -m py_compile audio_input.py main.py utils.py visualizer.py frames.py`


------
https://chatgpt.com/codex/tasks/task_e_6886862d5de48322ae8d7860111c9bc7