### PR TITLE
Switch waves to falling slashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Press `Ctrl+C` to exit.
 
 ### Controls
 
-Use the following keys at runtime:
+Use the following key bindings at runtime:
 
-- `+` / `-` to adjust the starting wave radius.
-- `[` / `]` to change how long spawned waves stay on screen.
+- `[` / `]` to adjust how long falling slashes remain visible.

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Press `Ctrl+C` to exit.
 
 Use the following key bindings at runtime:
 
-- `[` / `]` to adjust how long falling slashes remain visible.
+- `[` / `]` to change how long spawned slashes stay on screen.

--- a/audio_input.py
+++ b/audio_input.py
@@ -34,7 +34,6 @@ def audio_callback(indata, frames, time, status):
     last_amplitude = min(max(band_energy * 10, 0), 1)
 
 def get_amplitude_band():
-    global last_amplitude
     return last_amplitude
 
 # Choose device

--- a/main.py
+++ b/main.py
@@ -12,8 +12,7 @@ FPS = 30
 # Minimum amplitude considered a beat
 BEAT_THRESHOLD = 0.03  # Lowered for better sensitivity
 
-# Default starting values for user controlled wave properties
-DEFAULT_RADIUS = 3
+# Lifetime for falling slashes
 DEFAULT_TTL = 20
 
 
@@ -39,7 +38,6 @@ def main(stdscr: curses.window) -> None:
     stdscr.clear()
 
     active_slashes: list[Slash] = []
-    user_radius = DEFAULT_RADIUS
     user_ttl = DEFAULT_TTL
     message_timer = 0.0
 
@@ -47,13 +45,7 @@ def main(stdscr: curses.window) -> None:
         amplitude = get_amplitude_band()
         key = stdscr.getch()
 
-        if key == ord("+") or key == ord("="):
-            user_radius = min(user_radius + 1, 10)
-            message_timer = time.time()
-        elif key == ord("-") or key == ord("_"):
-            user_radius = max(user_radius - 1, 1)
-            message_timer = time.time()
-        elif key == ord("]"):
+        if key == ord("]"):
             user_ttl = min(user_ttl + 2, 30)
             message_timer = time.time()
         elif key == ord("["):
@@ -77,7 +69,6 @@ def main(stdscr: curses.window) -> None:
             amplitude,
             amplitude > BEAT_THRESHOLD,
             active_slashes,
-            user_radius,
             user_ttl,
             show_radius=(time.time() - message_timer < 2),
         )

--- a/main.py
+++ b/main.py
@@ -17,7 +17,9 @@ DEFAULT_TTL = 20
 
 
 class Slash:
-    def __init__(self, x, y, char, ttl=8):
+    """Simple falling slash character used for the visual effect."""
+
+    def __init__(self, x: int, y: int, char: str, ttl: int = 8) -> None:
         self.x = x
         self.y = y
         self.char = char

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,9 +1,18 @@
 import curses
+from typing import List
 
 from frames import OMARCHY_BANNER
 
 
-def draw_frame(stdscr, amplitude, show_banner, slashes, user_ttl, show_radius=False):
+def draw_frame(
+    stdscr: curses.window,
+    amplitude: float,
+    show_banner: bool,
+    slashes: List["Slash"],
+    user_ttl: int,
+    show_radius: bool = False,
+) -> None:
+    """Draw a single visualization frame."""
     stdscr.clear()
     height, width = stdscr.getmaxyx()
 

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,5 +1,4 @@
 import curses
-from typing import List
 
 from frames import OMARCHY_BANNER
 
@@ -18,10 +17,9 @@ class FlameParticle:
         self.ttl -= 1
 
 
-def draw_frame(stdscr, amplitude, show_banner, slashes, user_radius, user_ttl, show_radius=False):
+def draw_frame(stdscr, amplitude, show_banner, slashes, user_ttl, show_radius=False):
     stdscr.clear()
     height, width = stdscr.getmaxyx()
-    center_y, center_x = height // 2, width // 2
 
     if show_banner:
         bottom_start = height - len(OMARCHY_BANNER)

--- a/visualizer.py
+++ b/visualizer.py
@@ -3,20 +3,6 @@ import curses
 from frames import OMARCHY_BANNER
 
 
-class FlameParticle:
-    """Represents a temporary flame emoji flying out from the center."""
-
-    def __init__(self, angle: float, radius: float = 1.0, ttl: int = 4) -> None:
-        self.angle = angle
-        self.radius = radius
-        self.ttl = ttl
-
-    def update(self) -> None:
-        """Advance the particle one step outward and reduce its life."""
-        self.radius += 1
-        self.ttl -= 1
-
-
 def draw_frame(stdscr, amplitude, show_banner, slashes, user_ttl, show_radius=False):
     stdscr.clear()
     height, width = stdscr.getmaxyx()


### PR DESCRIPTION
## Summary
- replace the wave class with a Slash type
- drop flame and wave drawing logic
- display falling slashes on beats
- extend slash TTL so characters fall farther down the screen
- move OMARCHY banner to bottom center

## Testing
- `python -m py_compile *.py`
- `python main.py` *(fails: PortAudio library not found)*

------
https://chatgpt.com/codex/tasks/task_e_688694c2eac88322a77bc466caf74115