### PR TITLE
Fix OMARCHY banner alignment and extend rain

### DIFF
--- a/frames.py
+++ b/frames.py
@@ -31,16 +31,16 @@ HAND_FRAMES = [
     ],
 ]
 
-# OMARCHY banner generated with pyfiglet using the ansi_shadow font.
-# Left indentation is preserved so the banner can be drawn starting from the
-# left edge of the screen without further adjustment.
+# OMARCHY banner generated with ``pyfiglet`` using the ``ansi_shadow`` font.
+# The strings do not include any indentation so the banner can be centered on
+# the screen at runtime.
 OMARCHY_BANNER = [
-    "    ██████╗ ███╗   ███╗ █████╗ ██████╗  ██████╗██╗  ██╗██╗   ██╗",
-    "    ██╔═══██╗████╗ ████║██╔══██╗██╔══██╗██╔════╝██║  ██║╚██╗ ██╔╝",
-    "    ██║   ██║██╔████╔██║███████║██████╔╝██║     ███████║ ╚████╔╝ ",
-    "    ██║   ██║██║╚██╔╝██║██╔══██║██╔══██╗██║     ██╔══██║  ╚██╔╝  ",
-    "    ╚██████╔╝██║ ╚═╝ ██║██║  ██║██║  ██║╚██████╗██║  ██║   ██║   ",
-    "     ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝   "
+    " ██████╗ ███╗   ███╗ █████╗ ██████╗  ██████╗██╗  ██╗██╗   ██╗",
+    "██╔═══██╗████╗ ████║██╔══██╗██╔══██╗██╔════╝██║  ██║╚██╗ ██╔╝",
+    "██║   ██║██╔████╔██║███████║██████╔╝██║     ███████║ ╚████╔╝",
+    "██║   ██║██║╚██╔╝██║██╔══██║██╔══██╗██║     ██╔══██║  ╚██╔╝",
+    "╚██████╔╝██║ ╚═╝ ██║██║  ██║██║  ██║╚██████╗██║  ██║   ██║",
+    " ╚═════╝ ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝   ╚═╝",
 ]
 
 # Template for simple wave ring layers

--- a/visualizer.py
+++ b/visualizer.py
@@ -6,24 +6,21 @@ def draw_frame(stdscr, amplitude, slashes, user_ttl, show_radius=False):
     """Draw the current frame for the visualizer."""
     stdscr.clear()
     height, width = stdscr.getmaxyx()
-    mid_y = height // 2
+    omarchy_y = height - len(OMARCHY_BANNER) - 1
     center_x = width // 2
 
-    # Draw slashes falling to mid-screen
+    # Draw slashes falling from the top down to just above the OMARCHY banner
     for s in slashes:
-        if 0 <= s.y < mid_y and 0 <= s.x < width:
+        if 0 <= s.y < omarchy_y and 0 <= s.x < width:
             try:
                 stdscr.addstr(s.y, s.x, s.char, curses.A_BOLD)
             except curses.error:
                 continue
 
-    # Draw static OMARCHY banner at the bottom left. The banner lines already
-    # include their own indentation so we write them starting from column zero
-    # to keep the intended alignment.
-    omarchy_y = height - len(OMARCHY_BANNER) - 1
+    # Draw static OMARCHY banner centered at the bottom of the screen
     for i, line in enumerate(OMARCHY_BANNER):
         y = omarchy_y + i
-        x = 0
+        x = (width - len(line)) // 2
         try:
             stdscr.addstr(y, x, line, curses.A_BOLD)
         except curses.error:


### PR DESCRIPTION
## Summary
- fix OMARCHY ASCII art and remove leading indentation
- center OMARCHY banner horizontally at the bottom of the screen
- extend falling slashes so the rain reaches just above the OMARCHY banner

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6886a003dff08322a10f5e6490b90ef6