### PR TITLE
Fix OMARCHY banner alignment and extend rain

### DIFF
--- a/visualizer.py
+++ b/visualizer.py
@@ -1,17 +1,20 @@
 import curses
 from frames import OMARCHY_BANNER
 
+# Pre-compute the banner width so each line can be aligned consistently.
+BANNER_WIDTH = max(len(line) for line in OMARCHY_BANNER)
+
 
 def draw_frame(stdscr, amplitude, slashes, user_ttl, show_radius=False):
     """Draw the current frame for the visualizer."""
     stdscr.clear()
     height, width = stdscr.getmaxyx()
     omarchy_y = height - len(OMARCHY_BANNER) - 1
-    center_x = width // 2
+    banner_x = (width - BANNER_WIDTH) // 2
 
-    # Draw slashes falling from the top down to just above the OMARCHY banner
+    # Draw slashes falling through the entire screen area
     for s in slashes:
-        if 0 <= s.y < omarchy_y and 0 <= s.x < width:
+        if 0 <= s.y < height and 0 <= s.x < width:
             try:
                 stdscr.addstr(s.y, s.x, s.char, curses.A_BOLD)
             except curses.error:
@@ -20,9 +23,8 @@ def draw_frame(stdscr, amplitude, slashes, user_ttl, show_radius=False):
     # Draw static OMARCHY banner centered at the bottom of the screen
     for i, line in enumerate(OMARCHY_BANNER):
         y = omarchy_y + i
-        x = (width - len(line)) // 2
         try:
-            stdscr.addstr(y, x, line, curses.A_BOLD)
+            stdscr.addstr(y, banner_x, line, curses.A_BOLD)
         except curses.error:
             continue
 


### PR DESCRIPTION
## Summary
- allow falling slashes to reach the bottom of the screen
- center OMARCHY banner using a common width

## Testing
- `python -m py_compile audio_input.py frames.py main.py utils.py visualizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886a298b2d083229a76d2ac832ad991