### PR TITLE
Increase ttl for slashes

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,8 @@ FPS = 30
 BEAT_THRESHOLD = 0.03  # Lower for sensitivity
 
 # Default lifetime for spawned slashes
-DEFAULT_TTL = 10
+# Increased to allow slashes to fall across most of the screen
+DEFAULT_TTL = 30
 
 
 class Slash:

--- a/visualizer.py
+++ b/visualizer.py
@@ -13,8 +13,9 @@ def draw_frame(stdscr, amplitude, slashes, user_ttl, show_radius=False):
     banner_x = (width - BANNER_WIDTH) // 2
 
     # Draw slashes falling through the entire screen area
+    # Allow slashes to fall nearly to the bottom, stopping above the banner
+    mid_y = height - len(OMARCHY_BANNER) - 2
     for s in slashes:
-        mid_y = omarchy_y - 1  # just above the banner
         if 0 <= s.y < mid_y and 0 <= s.x < width:
             try:
                 stdscr.addstr(s.y, s.x, s.char, curses.A_BOLD)


### PR DESCRIPTION
## Summary
- allow slashes to stay on screen longer
- ensure slashes fall nearly to bottom before banner

## Testing
- `python -m py_compile main.py visualizer.py audio_input.py utils.py frames.py`


------
https://chatgpt.com/codex/tasks/task_e_6886a68534b08322b00a9f3a71c5d682