### PR TITLE
Fix missing banner import and rain distance

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@ import curses
 import time
 import random
 
+from frames import OMARCHY_BANNER
+
 from audio_input import get_amplitude_band
 from visualizer import draw_frame
 

--- a/visualizer.py
+++ b/visualizer.py
@@ -11,6 +11,7 @@ def draw_frame(stdscr, amplitude, slashes, user_ttl, show_radius=False):
     height, width = stdscr.getmaxyx()
     omarchy_y = height - len(OMARCHY_BANNER) - 1
     banner_x = (width - BANNER_WIDTH) // 2
+    rain_max_y = height - len(OMARCHY_BANNER) - 2
 
     # Draw falling slashes that do not overlap with the OMARCHY banner
     for s in slashes:


### PR DESCRIPTION
## Summary
- import `OMARCHY_BANNER` in `main.py`
- define `rain_max_y` in `visualizer.py` so slashes don't overlap the banner

## Testing
- `python -m py_compile main.py audio_input.py frames.py utils.py visualizer.py`
- `pip install -r requirements.txt` *(fails: PortAudio library not found)*
- `apt-get update`
- `apt-get install -y portaudio19-dev`
- `python main.py` *(fails: Error querying device -1)*

------
https://chatgpt.com/codex/tasks/task_e_6886abdf15cc8322a0888ab70f1be44d